### PR TITLE
Adds video filters processors to ios and android

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -295,6 +295,14 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
         result.success(null);
         break;
       }
+      case "setVideoEffects": {
+        String trackId = call.argument("trackId");
+        List<String> names = call.argument("names");
+        
+        getUserMediaImpl.setVideoEffect(trackId, names);
+        result.success(null);
+        break;
+      }
       case "createPeerConnection": {
         Map<String, Object> constraints = call.argument("constraints");
         Map<String, Object> configuration = call.argument("configuration");

--- a/android/src/main/java/com/cloudwebrtc/webrtc/videoEffects/ProcessorProvider.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/videoEffects/ProcessorProvider.java
@@ -1,0 +1,37 @@
+package com.cloudwebrtc.webrtc.videoEffects;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Manages VideoFrameProcessorFactoryInterfaces corresponding to name using hashmap, and provides
+ * get, add and remove functionality.
+ */
+public class ProcessorProvider {
+    private static Map<String, VideoFrameProcessorFactoryInterface> methodMap = new HashMap<String, VideoFrameProcessorFactoryInterface>();
+
+    public static VideoFrameProcessor getProcessor(String name) {
+        if (methodMap.containsKey(name)) {
+            return methodMap.get(name).build();
+        } else{
+            return null;
+        } 
+    }
+
+    public static void addProcessor(String name,
+            VideoFrameProcessorFactoryInterface videoFrameProcessorFactoryInterface) {
+        if (name != null && videoFrameProcessorFactoryInterface != null) {
+            methodMap.put(name, videoFrameProcessorFactoryInterface);
+        } else{
+            throw new NullPointerException("Name or VideoFrameProcessorFactry can not be null");
+        }
+    }
+
+    public static void removeProcessor(String name) {
+        if (name != null && methodMap.containsKey(name)) {
+            methodMap.remove(name);
+        } else{
+            throw new RuntimeException("VideoFrameProcessorFactry with " + name + " does not exist");
+        }
+    }
+}

--- a/android/src/main/java/com/cloudwebrtc/webrtc/videoEffects/VideoEffectProcessor.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/videoEffects/VideoEffectProcessor.java
@@ -1,0 +1,58 @@
+package com.cloudwebrtc.webrtc.videoEffects;
+
+import org.webrtc.SurfaceTextureHelper;
+import org.webrtc.VideoFrame;
+import org.webrtc.VideoProcessor;
+import org.webrtc.VideoSink;
+
+import java.util.List;
+
+/**
+ * Lightweight abstraction for an object that can receive video frames, process and add effects in
+ * them, and pass them on to another object.
+ */
+public class VideoEffectProcessor implements VideoProcessor {
+    private VideoSink mSink;
+    final private SurfaceTextureHelper textureHelper;
+    final private List<VideoFrameProcessor> videoFrameProcessors;
+
+    public VideoEffectProcessor(List<VideoFrameProcessor> processors, SurfaceTextureHelper textureHelper) {
+        this.textureHelper = textureHelper;
+        this.videoFrameProcessors = processors;
+    }
+
+    @Override
+    public void onCapturerStarted(boolean success) {
+
+    }
+
+    @Override
+    public void onCapturerStopped() {
+
+    }
+
+    @Override
+    public void setSink(VideoSink sink) {
+        mSink = sink;
+    }
+
+    /**
+     * Called just after the frame is captured.
+     * Will process the VideoFrame with the help of VideoFrameProcessor and send the processed
+     * VideoFrame back to webrtc using onFrame method in VideoSink.
+     * @param frame raw VideoFrame received from webrtc.
+     */
+    @Override
+    public void onFrameCaptured(VideoFrame frame) {
+        frame.retain();
+        VideoFrame outputFrame = frame;
+
+        for (VideoFrameProcessor processor : this.videoFrameProcessors) {
+            outputFrame = processor.process(outputFrame, textureHelper);
+        }
+
+        mSink.onFrame(outputFrame);
+        outputFrame.release();
+        frame.release();
+    }
+}

--- a/android/src/main/java/com/cloudwebrtc/webrtc/videoEffects/VideoFrameProcessor.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/videoEffects/VideoFrameProcessor.java
@@ -1,0 +1,19 @@
+package com.cloudwebrtc.webrtc.videoEffects;
+
+import org.webrtc.SurfaceTextureHelper;
+import org.webrtc.VideoFrame;
+
+/**
+ * Interface contains process method to process VideoFrame.
+ * The caller takes ownership of the object.
+ */
+public interface VideoFrameProcessor {
+    /**
+     * Applies the image processing algorithms to the frame. Returns the processed frame.
+     * The caller is responsible for releasing the returned frame.
+     * @param frame raw videoframe which need to be processed
+     * @param textureHelper
+     * @return processed videoframe which will rendered
+     */
+    public VideoFrame process(VideoFrame frame, SurfaceTextureHelper textureHelper);
+}

--- a/android/src/main/java/com/cloudwebrtc/webrtc/videoEffects/VideoFrameProcessorFactoryInterface.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/videoEffects/VideoFrameProcessorFactoryInterface.java
@@ -1,0 +1,13 @@
+package com.cloudwebrtc.webrtc.videoEffects;
+
+ /**
+  * Factory for creating VideoFrameProcessor instances.
+  */
+ public interface VideoFrameProcessorFactoryInterface {
+
+    /**
+    * Dynamically allocates a VideoFrameProcessor instance and returns a pointer to it.
+    * The caller takes ownership of the object.
+    */
+     public VideoFrameProcessor build();
+ }

--- a/common/darwin/Classes/FlutterWebRTCPlugin.h
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.h
@@ -7,6 +7,7 @@
 #import <Foundation/Foundation.h>
 #import <WebRTC/WebRTC.h>
 
+@class VideoEffectProcessor;
 @class FlutterRTCVideoRenderer;
 @class FlutterRTCFrameCapturer;
 
@@ -46,12 +47,15 @@ typedef void (^CapturerStopHandler)(CompletionHandler _Nonnull handler);
 @property(nonatomic, strong) RTCCameraVideoCapturer* _Nullable videoCapturer;
 @property(nonatomic, strong) FlutterRTCFrameCapturer* _Nullable frameCapturer;
 @property(nonatomic, strong) AVAudioSessionPort _Nullable preferredInput;
+@property (nonatomic, strong) VideoEffectProcessor* videoEffectProcessor;
 
 @property(nonatomic) BOOL _usingFrontCamera;
 @property(nonatomic) NSInteger _lastTargetWidth;
 @property(nonatomic) NSInteger _lastTargetHeight;
 @property(nonatomic) NSInteger _lastTargetFps;
 
+- (void)mediaStreamTrackSetVideoEffects:(nonnull NSString *)trackId 
+                                  names:(nonnull NSArray<NSString *> *)names;
 - (RTCMediaStream* _Nullable)streamForId:(NSString* _Nonnull)streamId peerConnectionId:(NSString* _Nullable)peerConnectionId;
 - (RTCMediaStreamTrack* _Nullable)trackForId:(NSString* _Nonnull)trackId peerConnectionId:(NSString* _Nullable)peerConnectionId;
 - (RTCRtpTransceiver* _Nullable)getRtpTransceiverById:(RTCPeerConnection* _Nonnull)peerConnection Id:(NSString* _Nullable)Id;

--- a/common/darwin/Classes/ProcessorProvider.h
+++ b/common/darwin/Classes/ProcessorProvider.h
@@ -1,0 +1,10 @@
+#import "VideoFrameProcessor.h"
+
+@interface ProcessorProvider : NSObject
+
++ (NSObject<VideoFrameProcessorDelegate> *)getProcessor:(NSString *)name;
++ (void)addProcessor:(NSObject<VideoFrameProcessorDelegate> *)processor
+             forName:(NSString *)name;
++ (void)removeProcessor:(NSString *)name;
+
+@end

--- a/common/darwin/Classes/ProcessorProvider.m
+++ b/common/darwin/Classes/ProcessorProvider.m
@@ -1,0 +1,24 @@
+#import "ProcessorProvider.h"
+
+@implementation ProcessorProvider
+
+static NSMutableDictionary<NSString *, NSObject<VideoFrameProcessorDelegate> *> *processorMap;
+
++ (void)initialize {
+  processorMap = [[NSMutableDictionary alloc] init];
+}
+
++ (NSObject<VideoFrameProcessorDelegate> *)getProcessor:(NSString *)name {
+  return [processorMap objectForKey:name];
+}
+
++ (void)addProcessor:(NSObject<VideoFrameProcessorDelegate> *)processor
+            forName:(NSString *)name {
+  [processorMap setObject:processor forKey:name];
+}
+
++ (void)removeProcessor:(NSString *)name {
+  [processorMap removeObjectForKey:name];
+}
+
+@end

--- a/common/darwin/Classes/VideoEffectProcessor.h
+++ b/common/darwin/Classes/VideoEffectProcessor.h
@@ -1,0 +1,13 @@
+#import <WebRTC/RTCVideoSource.h>
+
+#import "VideoFrameProcessor.h"
+
+@interface VideoEffectProcessor : NSObject<RTCVideoCapturerDelegate>
+
+@property (nonatomic, strong) NSArray<NSObject<VideoFrameProcessorDelegate> *> *videoFrameProcessors;
+@property (nonatomic, strong) RTCVideoSource *videoSource;
+
+- (instancetype)initWithProcessors:(NSArray<NSObject<VideoFrameProcessorDelegate> *> *)videoFrameProcessors
+                       videoSource:(RTCVideoSource *)videoSource;
+
+@end

--- a/common/darwin/Classes/VideoEffectProcessor.m
+++ b/common/darwin/Classes/VideoEffectProcessor.m
@@ -1,0 +1,19 @@
+#import <WebRTC/RTCVideoCapturer.h>
+#import "VideoEffectProcessor.h"
+
+@implementation VideoEffectProcessor
+- (instancetype)initWithProcessors:(NSArray<NSObject<VideoFrameProcessorDelegate> *> *)videoFrameProcessors
+                       videoSource:(RTCVideoSource *)videoSource {
+  self = [super init];
+  _videoFrameProcessors = videoFrameProcessors;
+  _videoSource = videoSource;
+  return self;
+}
+- (void)capturer:(nonnull RTCVideoCapturer *)capturer didCaptureVideoFrame:(nonnull RTCVideoFrame *)frame {
+  RTCVideoFrame *processedFrame = frame;
+  for (NSObject<VideoFrameProcessorDelegate> *processor in _videoFrameProcessors) {
+    processedFrame = [processor capturer:capturer didCaptureVideoFrame:processedFrame];
+  }
+  [self.videoSource capturer:capturer didCaptureVideoFrame:processedFrame];
+}
+@end

--- a/common/darwin/Classes/VideoFrameProcessor.h
+++ b/common/darwin/Classes/VideoFrameProcessor.h
@@ -1,0 +1,7 @@
+#import <WebRTC/RTCVideoCapturer.h>
+#import <WebRTC/RTCVideoFrame.h>
+
+@protocol VideoFrameProcessorDelegate
+- (RTCVideoFrame *)capturer:(RTCVideoCapturer *)capturer
+      didCaptureVideoFrame:(RTCVideoFrame *)frame;
+@end

--- a/ios/Classes/ProcessorProvider.h
+++ b/ios/Classes/ProcessorProvider.h
@@ -1,0 +1,1 @@
+../../common/darwin/Classes/ProcessorProvider.h

--- a/ios/Classes/ProcessorProvider.m
+++ b/ios/Classes/ProcessorProvider.m
@@ -1,0 +1,1 @@
+../../common/darwin/Classes/ProcessorProvider.m

--- a/ios/Classes/VideoEffectProcessor.h
+++ b/ios/Classes/VideoEffectProcessor.h
@@ -1,0 +1,1 @@
+../../common/darwin/Classes/VideoEffectProcessor.h

--- a/ios/Classes/VideoEffectProcessor.m
+++ b/ios/Classes/VideoEffectProcessor.m
@@ -1,0 +1,1 @@
+../../common/darwin/Classes/VideoEffectProcessor.m

--- a/ios/Classes/VideoFrameProcessor.h
+++ b/ios/Classes/VideoFrameProcessor.h
@@ -1,0 +1,1 @@
+../../common/darwin/Classes/VideoFrameProcessor.h

--- a/lib/src/native/factory_impl.dart
+++ b/lib/src/native/factory_impl.dart
@@ -19,6 +19,14 @@ class RTCFactoryNative extends RTCFactory {
   static final RTCFactory instance = RTCFactoryNative._internal();
 
   @override
+  Future<void> setVideoEffects(String trackId, List<String> names) async {
+    await WebRTC.invokeMethod('setVideoEffects', {
+      'trackId': trackId,
+      'names': names,
+    });
+  }
+
+  @override
   Future<MediaStream> createLocalMediaStream(String label) async {
     final response = await WebRTC.invokeMethod('createLocalMediaStream');
     if (response == null) {
@@ -88,6 +96,13 @@ class RTCFactoryNative extends RTCFactory {
     );
     return RTCRtpCapabilities.fromMap(response);
   }
+}
+
+Future<void> setVideoEffects(
+  String trackId, {
+  required List<String> names,
+}) async {
+  return RTCFactoryNative.instance.setVideoEffects(trackId, names);
 }
 
 Future<RTCPeerConnection> createPeerConnection(

--- a/macos/Classes/ProcessorProvider.h
+++ b/macos/Classes/ProcessorProvider.h
@@ -1,0 +1,1 @@
+../../common/darwin/Classes/ProcessorProvider.h

--- a/macos/Classes/ProcessorProvider.m
+++ b/macos/Classes/ProcessorProvider.m
@@ -1,0 +1,1 @@
+../../common/darwin/Classes/ProcessorProvider.m

--- a/macos/Classes/VideoEffectProcessor.h
+++ b/macos/Classes/VideoEffectProcessor.h
@@ -1,0 +1,1 @@
+../../common/darwin/Classes/VideoEffectProcessor.h

--- a/macos/Classes/VideoEffectProcessor.m
+++ b/macos/Classes/VideoEffectProcessor.m
@@ -1,0 +1,1 @@
+../../common/darwin/Classes/VideoEffectProcessor.m

--- a/macos/Classes/VideoFrameProcessor.h
+++ b/macos/Classes/VideoFrameProcessor.h
@@ -1,0 +1,1 @@
+../../common/darwin/Classes/VideoFrameProcessor.h


### PR DESCRIPTION
## Ticket
- https://linear.app/stream/issue/FLU-3/add-support-for-video-effects-in-webrtc-flutter


## Summary
This pull request introduces the necessary changes to implement video effects in our Flutter SDK. It allows developers to register VideoProcessors that can process each frame for various video effects. 

On Android, the video processor is set for the selected track's VideoSource. On iOS, it is configured as a delegate for the track's VideoCapturer. 

Additionally, the `setVideoEffects` platform channel method enables or disables the registered effects from Dart code.

Implementation based on the one done in RN:

Video Effect added in the original `react-native-webrtc` to Android:
https://github.com/react-native-webrtc/react-native-webrtc/pull/1176

Video Effects added in Stream's `react-native-webrtc` to iOS:
https://github.com/GetStream/react-native-webrtc/commit/3e80e4fa80188422574453d8c7b47bfa079ea550#diff-7c6e3881355f28853a9[…]3d5673456eb60fcd61253938