### PR TITLE
Feat: Added multitasking camera support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 --------------------------------------------
 
+[0.12.9+1] - 2025-02-17
+
+* [iOS] Added helper method `configureIOSMultitaskingCameraAccess` to enable/disable Multitasking Camrea Access on iOS
+
 [0.12.9] - 2025-02-13
 
 * [iOS] feat: Add option to start capture without broadcast picker (#1764)

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -853,11 +853,11 @@ bypassVoiceProcessing:(BOOL)bypassVoiceProcessing {
       result(nil);
     }
 #endif
-  else if ([@"configureMultitaskingCameraAccess" isEqualToString:call.method]) {
+  else if ([@"enableIOSMultitaskingCameraAccess" isEqualToString:call.method]) {
     NSDictionary* argsMap = call.arguments;
     BOOL enable = [argsMap[@"enable"] boolValue];
 
-    [self configureMultitaskingCameraAccess:enable result:result];
+    [self enableMultitaskingCameraAccess:enable result:result];
   } else if ([@"mediaStreamTrackHasTorch" isEqualToString:call.method]) {
     NSDictionary* argsMap = call.arguments;
     NSString* trackId = argsMap[@"trackId"];
@@ -1593,18 +1593,18 @@ bypassVoiceProcessing:(BOOL)bypassVoiceProcessing {
   }
 }
 
-- (void)configureMultitaskingCameraAccess:(BOOL)enable result:(FlutterResult)result
+- (void)enableMultitaskingCameraAccess:(BOOL)enable result:(FlutterResult)result
 {
     @try {
         AVCaptureSession *session = self.videoCapturer.captureSession;
         if (session == nil) {
-            NSLog(@"configureMultitaskingCameraAccess: Capture session is nil.");
+            NSLog(@"enableMultitaskingCameraAccess: Capture session is nil.");
             result(@NO);
             return;
         }
 
         #if TARGET_OS_OSX
-            NSLog(@"configureMultitaskingCameraAccess: Multitasking camera access is not available on macOS.");
+            NSLog(@"enableMultitaskingCameraAccess: Multitasking camera access is not available on macOS.");
             result(@NO);
             return;
         #else
@@ -1620,21 +1620,21 @@ bypassVoiceProcessing:(BOOL)bypassVoiceProcessing {
                     result(enable ? @YES : @NO);
                 } else {
                     if (!canChange) {
-                        NSLog(@"configureMultitaskingCameraAccess: Multitasking camera access is not supported on this device.");
+                        NSLog(@"enableMultitaskingCameraAccess: Multitasking camera access is not supported on this device.");
                         result(@NO);
                     } else {
-                        NSLog(@"configureMultitaskingCameraAccess: Multitasking camera access is already %@.", enable ? @"enabled" : @"disabled");
+                        NSLog(@"enableMultitaskingCameraAccess: Multitasking camera access is already %@.", enable ? @"enabled" : @"disabled");
                         result(enable ? @YES : @NO);
                     }
                 }
             } else {
-                NSLog(@"configureMultitaskingCameraAccess: Multitasking camera access requires iOS 16 or later.");
+                NSLog(@"enableMultitaskingCameraAccess: Multitasking camera access requires iOS 16 or later.");
                 result(@NO);
             }
         #endif
     }
     @catch (NSException *exception) {
-        NSLog(@"configureMultitaskingCameraAccess: Exception occurred: %@ - %@", exception.name, exception.reason);
+        NSLog(@"enableMultitaskingCameraAccess: Exception occurred: %@ - %@", exception.name, exception.reason);
         result(@NO);
     }
 }

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -853,7 +853,12 @@ bypassVoiceProcessing:(BOOL)bypassVoiceProcessing {
       result(nil);
     }
 #endif
-     else if ([@"mediaStreamTrackHasTorch" isEqualToString:call.method]) {
+  else if ([@"configureMultitaskingCameraAccess" isEqualToString:call.method]) {
+    NSDictionary* argsMap = call.arguments;
+    BOOL enable = [argsMap[@"enable"] boolValue];
+
+    [self configureMultitaskingCameraAccess:enable result:result];
+  } else if ([@"mediaStreamTrackHasTorch" isEqualToString:call.method]) {
     NSDictionary* argsMap = call.arguments;
     NSString* trackId = argsMap[@"trackId"];
     id<LocalTrack> track = self.localTracks[trackId];
@@ -1586,8 +1591,46 @@ bypassVoiceProcessing:(BOOL)bypassVoiceProcessing {
   } else {
     NSLog(@"mediaStreamTrackSetVideoEffects: track not found");
   }
+}
 
+- (void)configureMultitaskingCameraAccess:(BOOL)enable result:(FlutterResult)result
+{
+    @try {
+        AVCaptureSession *session = self.videoCapturer.captureSession;
+        if (session == nil) {
+            NSLog(@"configureMultitaskingCameraAccess: Capture session is nil.");
+            result(@NO);
+            return;
+        }
+        
+        if (@available(iOS 16.0, *)) {
+            BOOL shouldChange = session.multitaskingCameraAccessEnabled != enable;
+            BOOL canChange = !enable || (enable && session.isMultitaskingCameraAccessSupported);
 
+            if (shouldChange && canChange) {
+                [session beginConfiguration];
+                [session setMultitaskingCameraAccessEnabled:enable];
+                [session commitConfiguration];
+
+                result(enable ? @YES : @NO);
+            } else {
+                if (!canChange) {
+                    NSLog(@"configureMultitaskingCameraAccess: Multitasking camera access is not supported on this device.");
+                    result(@NO);
+                } else {
+                    NSLog(@"configureMultitaskingCameraAccess: Multitasking camera access is already %@.", enable ? @"enabled" : @"disabled");
+                    result(enable ? @YES : @NO);
+                }
+            }
+        } else {
+            NSLog(@"configureMultitaskingCameraAccess: Multitasking camera access requires iOS 16 or later.");
+            result(@NO);
+        }
+    }
+    @catch (NSException *exception) {
+        NSLog(@"configureMultitaskingCameraAccess: Exception occurred: %@ - %@", exception.name, exception.reason);
+        result(@NO);
+    }
 }
 
 - (void)mediaStreamGetTracks:(NSString*)streamId result:(FlutterResult)result {

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -1607,31 +1607,31 @@ bypassVoiceProcessing:(BOOL)bypassVoiceProcessing {
             NSLog(@"configureMultitaskingCameraAccess: Multitasking camera access is not available on macOS.");
             result(@NO);
             return;
-        #endif
+        #else
+            if (@available(iOS 16.0, *)) {
+                BOOL shouldChange = session.multitaskingCameraAccessEnabled != enable;
+                BOOL canChange = !enable || (enable && session.isMultitaskingCameraAccessSupported);
 
-        if (@available(iOS 16.0, *)) {
-            BOOL shouldChange = session.multitaskingCameraAccessEnabled != enable;
-            BOOL canChange = !enable || (enable && session.isMultitaskingCameraAccessSupported);
+                if (shouldChange && canChange) {
+                    [session beginConfiguration];
+                    [session setMultitaskingCameraAccessEnabled:enable];
+                    [session commitConfiguration];
 
-            if (shouldChange && canChange) {
-                [session beginConfiguration];
-                [session setMultitaskingCameraAccessEnabled:enable];
-                [session commitConfiguration];
-
-                result(enable ? @YES : @NO);
-            } else {
-                if (!canChange) {
-                    NSLog(@"configureMultitaskingCameraAccess: Multitasking camera access is not supported on this device.");
-                    result(@NO);
-                } else {
-                    NSLog(@"configureMultitaskingCameraAccess: Multitasking camera access is already %@.", enable ? @"enabled" : @"disabled");
                     result(enable ? @YES : @NO);
+                } else {
+                    if (!canChange) {
+                        NSLog(@"configureMultitaskingCameraAccess: Multitasking camera access is not supported on this device.");
+                        result(@NO);
+                    } else {
+                        NSLog(@"configureMultitaskingCameraAccess: Multitasking camera access is already %@.", enable ? @"enabled" : @"disabled");
+                        result(enable ? @YES : @NO);
+                    }
                 }
+            } else {
+                NSLog(@"configureMultitaskingCameraAccess: Multitasking camera access requires iOS 16 or later.");
+                result(@NO);
             }
-        } else {
-            NSLog(@"configureMultitaskingCameraAccess: Multitasking camera access requires iOS 16 or later.");
-            result(@NO);
-        }
+        #endif
     }
     @catch (NSException *exception) {
         NSLog(@"configureMultitaskingCameraAccess: Exception occurred: %@ - %@", exception.name, exception.reason);

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -1602,7 +1602,13 @@ bypassVoiceProcessing:(BOOL)bypassVoiceProcessing {
             result(@NO);
             return;
         }
-        
+
+        #if TARGET_OS_OSX
+            NSLog(@"configureMultitaskingCameraAccess: Multitasking camera access is not available on macOS.");
+            result(@NO);
+            return;
+        #endif
+
         if (@available(iOS 16.0, *)) {
             BOOL shouldChange = session.multitaskingCameraAccessEnabled != enable;
             BOOL canChange = !enable || (enable && session.isMultitaskingCameraAccessSupported);

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -180,15 +180,15 @@ class Helper {
     }
   }
 
-  static Future<bool> configureIOSMultitaskingCameraAccess(bool enable) async {
+  static Future<bool> enableIOSMultitaskingCameraAccess(bool enable) async {
     if (WebRTC.platformIsIOS) {
       return await WebRTC.invokeMethod(
-        'configureIOSMultitaskingCameraAccess',
+        'enableIOSMultitaskingCameraAccess',
         <String, dynamic>{'enable': enable},
       );
     } else {
       throw Exception(
-          'configureIOSMultitaskingCameraAccess is only supported for iOS');
+          'enableIOSMultitaskingCameraAccess is only supported for iOS');
     }
   }
 }

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -179,4 +179,16 @@ class Helper {
       throw Exception('requestCapturePermission only support for Android');
     }
   }
+
+  static Future<bool> configureIOSMultitaskingCameraAccess(bool enable) async {
+    if (WebRTC.platformIsIOS) {
+      return await WebRTC.invokeMethod(
+        'configureIOSMultitaskingCameraAccess',
+        <String, dynamic>{'enable': enable},
+      );
+    } else {
+      throw Exception(
+          'configureIOSMultitaskingCameraAccess is only supported for iOS');
+    }
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stream_webrtc_flutter
 description: Flutter WebRTC plugin for iOS/Android/Destkop/Web, based on GoogleWebRTC.
-version: 0.12.9
+version: 0.12.9+1
 homepage: https://github.com/GetStream/webrtc-flutter
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
This pull request introduces a new feature to enable or disable multitasking camera access on iOS. The changes include adding a helper method and updating the method call handling.

### New Feature: Multitasking Camera Access on iOS

* `common/darwin/Classes/FlutterWebRTCPlugin.m`: 
  - Updated method call handling to include `ensureIOSMultitaskingCameraAccess`.
  - Added the implementation of `ensureMultitaskingCameraAccess` to configure multitasking camera access based on the provided argument.

* [`lib/src/helper.dart`](diffhunk://#diff-0730f7244987f77976094a672f55f4401ca3cd433c91e8dcfe8ab7c1525fa620R182-R193): Added a static method `ensureIOSMultitaskingCameraAccess` to the `Helper` class to invoke the new iOS functionality.