### PR TITLE
Downgrade dart_webrtc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 # Changelog
+[0.12.12+1] - 2025-03-11
+* [web] downgrade dart_webrtc dependency
 
 [0.12.12] - 2025-03-09
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stream_webrtc_flutter
 description: Flutter WebRTC plugin for iOS/Android/Destkop/Web, based on GoogleWebRTC.
-version: 0.12.12
+version: 0.12.12+1
 homepage: https://github.com/GetStream/webrtc-flutter
 environment:
   sdk: ">=3.3.0 <4.0.0"
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   collection: ^1.17.0
-  dart_webrtc: ^1.5.2+hotfix.1
+  dart_webrtc: ">=1.4.0 <1.5.0"
   flutter:
     sdk: flutter
   path_provider: ^2.0.2


### PR DESCRIPTION
dart_webrtc currently has a fatal bug for stats, so we downgrade to a version that works.