### PR TITLE
chore: sync with flutter_webrtc v0.12.12+hotfix.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,11 @@
 
 # Changelog
+
+[0.12.12+2] - 2025-03-12
+* [Android] fix: fixed video not rendered after resume from background.
+
 [0.12.12+1] - 2025-03-11
 * [web] downgrade dart_webrtc dependency
-
-[0.2.0] - 2025-03-11
-
-* [Android/iOS] Now using Stream's native WebRTC builds for improved performance and compatibility.
-* [Android] Introduced `AudioProcessingFactoryProvider` and updated `AudioProcessingController` to implement it, enabling enhanced customization of audio processing.
 
 [0.12.12] - 2025-03-09
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ android {
 }
 
 dependencies {
-    implementation 'io.getstream:stream-webrtc-android:1.3.8'
+    implementation 'io.github.webrtc-sdk:android:125.6422.03'
     implementation 'com.github.davidliu:audioswitch:89582c47c9a04c62f90aa5e57251af4800a62c9a'
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/android/src/main/java/io/getstream/webrtc/flutter/SurfaceTextureRenderer.java
+++ b/android/src/main/java/io/getstream/webrtc/flutter/SurfaceTextureRenderer.java
@@ -134,6 +134,7 @@ public class SurfaceTextureRenderer extends EglRenderer {
     final CountDownLatch completionLatch = new CountDownLatch(1);
     releaseEglSurface(completionLatch::countDown);
     ThreadUtils.awaitUninterruptibly(completionLatch);
+    surface = null;
   }
 
   // Update frame dimensions and report any changes to |rendererEvents|.

--- a/ios/stream_webrtc_flutter.podspec
+++ b/ios/stream_webrtc_flutter.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'StreamWebRTC', '125.6422.064'
+  s.dependency 'WebRTC-SDK', '125.6422.06'
   s.ios.deployment_target = '13.0'
   s.static_framework = true
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stream_webrtc_flutter
 description: Flutter WebRTC plugin for iOS/Android/Destkop/Web, based on GoogleWebRTC.
-version: 0.12.12+1
+version: 0.12.12+2
 homepage: https://github.com/GetStream/webrtc-flutter
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
Sync with flutter_webrtc v0.12.12+hotfix.1 and revert accidental internal Stream webrtc build usage.