### PR TITLE
feat: force sw codec for AV1 by default on Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ example/ios/Flutter/flutter_export_environment.sh
 .pub/
 /build/
 /android/.gradle/
+**/android/app/.cxx
 
 
 android/.classpath

--- a/android/src/main/java/io/getstream/webrtc/flutter/MethodCallHandlerImpl.java
+++ b/android/src/main/java/io/getstream/webrtc/flutter/MethodCallHandlerImpl.java
@@ -333,8 +333,9 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
             forceSWCodecList.add(v.toString());
           }
         } else {
-          // disable HW Codec for VP9 by default.
+          // disable HW Codec for VP9 and AV1 by default.
           forceSWCodecList.add("VP9");
+          forceSWCodecList.add("AV1");
         }
 
         ConstraintsMap androidAudioConfiguration = null;


### PR DESCRIPTION
Fixes FLU-81

We want to always use software encoding/decoding for AV1 as we have mixed results with hardware decoding on multiple devices.