### PR TITLE
fix: null check on getLocalDescription Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 # Changelog
+[1.0.8] - 2025-06-20
+* [Android] Fix `getLocalDescription` throwing an exception when it's `null`
 
 [1.0.7] - 2025-06-10
 * Added `handleCallInterruptionCallbacks` method to provide an option to handle system audio interruption like incoming calls, or other media playing

--- a/android/src/main/java/io/getstream/webrtc/flutter/MethodCallHandlerImpl.java
+++ b/android/src/main/java/io/getstream/webrtc/flutter/MethodCallHandlerImpl.java
@@ -863,10 +863,14 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
         PeerConnection peerConnection = getPeerConnection(peerConnectionId);
         if (peerConnection != null) {
           SessionDescription sdp = peerConnection.getLocalDescription();
-          ConstraintsMap params = new ConstraintsMap();
-          params.putString("sdp", sdp.description);
-          params.putString("type", sdp.type.canonicalForm());
-          result.success(params.toMap());
+          if (sdp == null) {
+            result.success(null);
+          } else {
+            ConstraintsMap params = new ConstraintsMap();
+            params.putString("sdp", sdp.description);
+            params.putString("type", sdp.type.canonicalForm());
+            result.success(params.toMap());
+          }
         } else {
           resultError("getLocalDescription", "peerConnection is null", result);
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stream_webrtc_flutter
 description: Flutter WebRTC plugin for iOS/Android/Destkop/Web, based on GoogleWebRTC.
-version: 1.0.7
+version: 1.0.8
 homepage: https://github.com/GetStream/webrtc-flutter
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
Android is the only place where we don't expect local description to be null, which can lead to a crash on `sdp.description`.
Other parts (iOS and Flutter) already expect local description to be nullable.

[Existing iOS code:](https://github.com/flutter-webrtc/flutter-webrtc/blob/main/common/darwin/Classes/FlutterWebRTCPlugin.m#L1052-L1059)
```objective-c
    if (peerConnection) {
      RTCSessionDescription* sdp = peerConnection.localDescription;
      if (nil == sdp) {
        result(nil);
      } else {
        NSString* type = [RTCSessionDescription stringForType:sdp.type];
        result(@{@"sdp" : sdp.sdp, @"type" : type});
      }
    } 
```

[Existing Flutter code:](https://github.com/flutter-webrtc/flutter-webrtc/blob/main/lib/src/native/rtc_peerconnection_impl.dart#L404-L411)
```dart
      final response =
          await WebRTC.invokeMethod('getLocalDescription', <String, dynamic>{
        'peerConnectionId': _peerConnectionId,
      });

      if (null == response) {
        return null;
      }
      String sdp = response['sdp'];
      String type = response['type'];
      return RTCSessionDescription(sdp, type);
```