### PR TITLE
disable software encoding for android

### DIFF
--- a/android/src/main/java/io/getstream/webrtc/flutter/MethodCallHandlerImpl.java
+++ b/android/src/main/java/io/getstream/webrtc/flutter/MethodCallHandlerImpl.java
@@ -273,8 +273,9 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
 
     videoDecoderFactory.setForceSWCodec(forceSWCodec);
     videoDecoderFactory.setForceSWCodecList(forceSWCodecList);
-    videoEncoderFactory.setForceSWCodec(forceSWCodec);
-    videoEncoderFactory.setForceSWCodecList(forceSWCodecList);
+// Disabled software encoding for now, only using software decoding. See FLU-120
+//    videoEncoderFactory.setForceSWCodec(forceSWCodec);
+//    videoEncoderFactory.setForceSWCodecList(forceSWCodecList);
 
 
     if(audioProcessingFactoryProvider == null) {


### PR DESCRIPTION
For now we want to disable software encoding and only keep software decoding for specific codecs.