### PR TITLE
feat: audio attributes configuration on focus manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 # Changelog
 
+[1.0.11] - 2025-08-13
+* [Android] Added option to configure Android audio attributes in AudioFocusManager
+
 [1.0.10] - 2025-08-07
 * [Linux/Windows] added missing cloneTrack method
 

--- a/android/src/main/java/io/getstream/webrtc/flutter/audio/AudioFocusManager.java
+++ b/android/src/main/java/io/getstream/webrtc/flutter/audio/AudioFocusManager.java
@@ -164,6 +164,7 @@ public class AudioFocusManager {
                 return AudioManager.STREAM_ALARM;
             }
         }
+        
         if (contentType != null) {
             if (contentType == AudioAttributes.CONTENT_TYPE_MUSIC
                     || contentType == AudioAttributes.CONTENT_TYPE_MOVIE) {
@@ -173,7 +174,8 @@ public class AudioFocusManager {
                 return AudioManager.STREAM_VOICE_CALL;
             }
         }
-        return AudioManager.STREAM_MUSIC;
+
+        return AudioManager.STREAM_VOICE_CALL;
     }
     
     private void registerTelephonyListener() {

--- a/android/src/main/java/io/getstream/webrtc/flutter/audio/AudioFocusManager.java
+++ b/android/src/main/java/io/getstream/webrtc/flutter/audio/AudioFocusManager.java
@@ -33,18 +33,27 @@ public class AudioFocusManager {
     private InterruptionSource interruptionSource;
     private Context context;
     
+    private Integer focusUsageType; // AudioAttributes.USAGE_*
+    private Integer focusContentType; // AudioAttributes.CONTENT_TYPE_*
+    
     public interface AudioFocusChangeListener {
         void onInterruptionStart();
         void onInterruptionEnd();
     }
     
     public AudioFocusManager(Context context) {
-        this(context, InterruptionSource.AUDIO_FOCUS_AND_TELEPHONY);
+        this(context, InterruptionSource.AUDIO_FOCUS_AND_TELEPHONY, null, null);
     }
     
     public AudioFocusManager(Context context, InterruptionSource interruptionSource) {
+        this(context, interruptionSource, null, null);
+    }
+    
+    public AudioFocusManager(Context context, InterruptionSource interruptionSource, Integer usageType, Integer contentType) {
         this.context = context;
         this.interruptionSource = interruptionSource;
+        this.focusUsageType = usageType;
+        this.focusContentType = contentType;
         
         if (interruptionSource == InterruptionSource.AUDIO_FOCUS_ONLY || 
             interruptionSource == InterruptionSource.AUDIO_FOCUS_AND_TELEPHONY) {
@@ -117,8 +126,8 @@ public class AudioFocusManager {
         
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             AudioAttributes audioAttributes = new AudioAttributes.Builder()
-                    .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
-                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .setUsage(focusUsageType != null ? focusUsageType : AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                    .setContentType(focusContentType != null ? focusContentType : AudioAttributes.CONTENT_TYPE_SPEECH)
                     .build();
                     
             audioFocusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
@@ -128,10 +137,43 @@ public class AudioFocusManager {
                     
             audioManager.requestAudioFocus(audioFocusRequest);
         } else {
+            int streamType = inferPreOStreamType(focusUsageType, focusContentType);
             audioManager.requestAudioFocus(onAudioFocusChangeListener,
-                    AudioManager.STREAM_VOICE_CALL,
+                    streamType,
                     AudioManager.AUDIOFOCUS_GAIN);
         }
+    }
+    
+    private int inferPreOStreamType(Integer usageType, Integer contentType) {
+        if (usageType != null) {
+            if (usageType == AudioAttributes.USAGE_MEDIA
+                    || usageType == AudioAttributes.USAGE_GAME
+                    || usageType == AudioAttributes.USAGE_ASSISTANT) {
+                return AudioManager.STREAM_MUSIC;
+            }
+            if (usageType == AudioAttributes.USAGE_VOICE_COMMUNICATION
+                    || usageType == AudioAttributes.USAGE_VOICE_COMMUNICATION_SIGNALLING) {
+                return AudioManager.STREAM_VOICE_CALL;
+            }
+            if (usageType == AudioAttributes.USAGE_NOTIFICATION
+                    || usageType == AudioAttributes.USAGE_NOTIFICATION_RINGTONE
+                    || usageType == AudioAttributes.USAGE_NOTIFICATION_COMMUNICATION_REQUEST) {
+                return AudioManager.STREAM_NOTIFICATION;
+            }
+            if (usageType == AudioAttributes.USAGE_ALARM) {
+                return AudioManager.STREAM_ALARM;
+            }
+        }
+        if (contentType != null) {
+            if (contentType == AudioAttributes.CONTENT_TYPE_MUSIC
+                    || contentType == AudioAttributes.CONTENT_TYPE_MOVIE) {
+                return AudioManager.STREAM_MUSIC;
+            }
+            if (contentType == AudioAttributes.CONTENT_TYPE_SPEECH) {
+                return AudioManager.STREAM_VOICE_CALL;
+            }
+        }
+        return AudioManager.STREAM_MUSIC;
     }
     
     private void registerTelephonyListener() {

--- a/ios/stream_webrtc_flutter.podspec
+++ b/ios/stream_webrtc_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'stream_webrtc_flutter'
-  s.version          = '1.0.10'
+  s.version          = '1.0.11'
   s.summary          = 'Flutter WebRTC plugin for iOS.'
   s.description      = <<-DESC
 A new flutter plugin project.

--- a/lib/src/android_interruption_source.dart
+++ b/lib/src/android_interruption_source.dart
@@ -1,5 +1,0 @@
-enum AndroidInterruptionSource {
-  audioFocusOnly,
-  telephonyOnly,
-  audioFocusAndTelephony,
-}

--- a/lib/src/native/android/audio_configuration.dart
+++ b/lib/src/native/android/audio_configuration.dart
@@ -25,6 +25,12 @@ extension AndroidAudioFocusModeEnumEx on String {
       AndroidAudioFocusMode.values.firstWhere((d) => d.name == toLowerCase());
 }
 
+enum AndroidInterruptionSource {
+  audioFocusOnly,
+  telephonyOnly,
+  audioFocusAndTelephony,
+}
+
 enum AndroidAudioStreamType {
   accessibility,
   alarm,

--- a/lib/src/native/factory_impl.dart
+++ b/lib/src/native/factory_impl.dart
@@ -3,8 +3,8 @@ import 'dart:io';
 
 import 'package:webrtc_interface/webrtc_interface.dart';
 
-import '../android_interruption_source.dart';
 import '../desktop_capturer.dart';
+import 'android/audio_configuration.dart';
 import 'desktop_capturer_impl.dart';
 import 'frame_cryptor_impl.dart';
 import 'media_recorder_impl.dart';
@@ -32,6 +32,8 @@ class RTCFactoryNative extends RTCFactory {
     void Function()? onInterruptionEnd, {
     AndroidInterruptionSource androidInterruptionSource =
         AndroidInterruptionSource.audioFocusAndTelephony,
+    AndroidAudioAttributesUsageType? androidAudioAttributesUsageType,
+    AndroidAudioAttributesContentType? androidAudioAttributesContentType,
   }) async {
     if (!Platform.isAndroid && !Platform.isIOS) {
       throw UnimplementedError(
@@ -43,6 +45,12 @@ class RTCFactoryNative extends RTCFactory {
       <String, dynamic>{
         if (Platform.isAndroid)
           'androidInterruptionSource': androidInterruptionSource.name,
+        if (Platform.isAndroid && androidAudioAttributesUsageType != null)
+          'androidAudioAttributesUsageType':
+              androidAudioAttributesUsageType.name,
+        if (Platform.isAndroid && androidAudioAttributesContentType != null)
+          'androidAudioAttributesContentType':
+              androidAudioAttributesContentType.name,
       },
     );
 
@@ -136,12 +144,16 @@ Future<void> handleCallInterruptionCallbacks(
   void Function()? onInterruptionEnd, {
   AndroidInterruptionSource androidInterruptionSource =
       AndroidInterruptionSource.audioFocusAndTelephony,
+  AndroidAudioAttributesUsageType? androidAudioAttributesUsageType,
+  AndroidAudioAttributesContentType? androidAudioAttributesContentType,
 }) {
   return (RTCFactoryNative.instance as RTCFactoryNative)
       .handleCallInterruptionCallbacks(
     onInterruptionStart,
     onInterruptionEnd,
     androidInterruptionSource: androidInterruptionSource,
+    androidAudioAttributesUsageType: androidAudioAttributesUsageType,
+    androidAudioAttributesContentType: androidAudioAttributesContentType,
   );
 }
 

--- a/lib/src/web/factory_impl.dart
+++ b/lib/src/web/factory_impl.dart
@@ -1,4 +1,3 @@
-import '../android_interruption_source.dart';
 import '../desktop_capturer.dart';
 
 export 'package:dart_webrtc/dart_webrtc.dart'
@@ -16,7 +15,9 @@ Future<void> setVideoEffects(
 Future<void> handleCallInterruptionCallbacks(
   void Function()? onInterruptionStart,
   void Function()? onInterruptionEnd, {
-  AndroidInterruptionSource? androidInterruptionSource,
+  Object? androidInterruptionSource,
+  Object? androidAudioAttributesUsageType,
+  Object? androidAudioAttributesContentType,
 }) {
   throw UnimplementedError(
       'handleCallInterruptionCallbacks() is not supported on web');

--- a/lib/stream_webrtc_flutter.dart
+++ b/lib/stream_webrtc_flutter.dart
@@ -3,7 +3,6 @@ library flutter_webrtc;
 export 'package:webrtc_interface/webrtc_interface.dart'
     hide MediaDevices, MediaRecorder, Navigator;
 
-export 'src/android_interruption_source.dart';
 export 'src/helper.dart';
 export 'src/desktop_capturer.dart';
 export 'src/media_devices.dart';

--- a/macos/stream_webrtc_flutter.podspec
+++ b/macos/stream_webrtc_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'stream_webrtc_flutter'
-  s.version          = '1.0.10'
+  s.version          = '1.0.11'
   s.summary          = 'Flutter WebRTC plugin for macOS.'
   s.description      = <<-DESC
 A new flutter plugin project.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stream_webrtc_flutter
 description: Flutter WebRTC plugin for iOS/Android/Destkop/Web, based on GoogleWebRTC.
-version: 1.0.10
+version: 1.0.11
 homepage: https://github.com/GetStream/webrtc-flutter
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
Previously, `AudioFocusManager` ignored the audio configuration set during WebRTC initialization when regaining focus and always used hardcoded values. This PR changes that and uses the configured values when requesting focus.