### PR TITLE
fix: fixed audioPlayout pause on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 # Changelog
 
+[2.2.6] - 2026-02-24
+* [iOS] Fixed the implementation of pause/resumeAudioPlayout.
+
 [2.2.5] - 2026-02-13
 * [iOS] Added `Helper.setiOSStereoPlayoutPreferred()`, `Helper.isiOSStereoPlayoutEnabled()`, and `Helper.refreshiOSStereoPlayoutState()` to enable and manage stereo audio playout. When enabled, the native layer configures the ADM for stereo output, bypasses voice processing, and automatically re-evaluates stereo state on audio route changes.
 * Added support for reinitializing the WebRTC plugin via `WebRTC.initialize(options: {'reinitialize': true})` to allow reconfiguring audio and video parameters (e.g., `audioSampleRate`, `audioOutputSampleRate`) at runtime without requiring an app restart.

--- a/common/darwin/Classes/FlutterRTCPeerConnection.m
+++ b/common/darwin/Classes/FlutterRTCPeerConnection.m
@@ -179,6 +179,11 @@
 - (void)peerConnectionClose:(RTCPeerConnection*)peerConnection {
   [peerConnection close];
 
+  for (NSString* trackId in peerConnection.remoteTracks) {
+    [self.pausedTrackVolumes removeObjectForKey:trackId];
+    [self.trackVolumeCache removeObjectForKey:trackId];
+  }
+
   // Clean up peerConnection's streams and tracks
   [peerConnection.remoteStreams removeAllObjects];
   [peerConnection.remoteTracks removeAllObjects];
@@ -412,6 +417,18 @@
   NSString* streamId = stream.streamId;
   peerConnection.remoteStreams[streamId] = stream;
 
+  if ([track isKindOfClass:[RTCAudioTrack class]]) {
+    RTCAudioTrack* audioTrack = (RTCAudioTrack*)track;
+    NSString* trackId = track.trackId;
+    if (self.trackVolumeCache[trackId] == nil) {
+      self.trackVolumeCache[trackId] = @(1.0);
+    }
+    if (self.isAudioPlayoutPaused) {
+      self.pausedTrackVolumes[trackId] = self.trackVolumeCache[trackId];
+      audioTrack.source.volume = 0.0;
+    }
+  }
+
   FlutterEventSink eventSink = peerConnection.eventSink;
   if (eventSink) {
     postEvent(eventSink, @{
@@ -434,6 +451,8 @@
            mediaStream:(RTCMediaStream*)stream
         didRemoveTrack:(RTCVideoTrack*)track {
   [peerConnection.remoteTracks removeObjectForKey:track.trackId];
+  [self.pausedTrackVolumes removeObjectForKey:track.trackId];
+  [self.trackVolumeCache removeObjectForKey:track.trackId];
   NSString* streamId = stream.streamId;
   FlutterEventSink eventSink = peerConnection.eventSink;
   if (eventSink) {
@@ -460,10 +479,18 @@
   BOOL hasAudio = NO;
   for (RTCAudioTrack* track in stream.audioTracks) {
     peerConnection.remoteTracks[track.trackId] = track;
+    NSString* trackId = track.trackId;
+    if (self.trackVolumeCache[trackId] == nil) {
+      self.trackVolumeCache[trackId] = @(1.0);
+    }
+    if (self.isAudioPlayoutPaused) {
+      self.pausedTrackVolumes[trackId] = self.trackVolumeCache[trackId];
+      track.source.volume = 0.0;
+    }
     [audioTracks addObject:@{
-      @"id" : track.trackId,
+      @"id" : trackId,
       @"kind" : track.kind,
-      @"label" : track.trackId,
+      @"label" : trackId,
       @"enabled" : @(track.isEnabled),
       @"remote" : @(YES),
       @"readyState" : @"live"
@@ -515,6 +542,8 @@
   }
   for (RTCAudioTrack* track in stream.audioTracks) {
     [peerConnection.remoteTracks removeObjectForKey:track.trackId];
+    [self.pausedTrackVolumes removeObjectForKey:track.trackId];
+    [self.trackVolumeCache removeObjectForKey:track.trackId];
   }
 
   FlutterEventSink eventSink = peerConnection.eventSink;
@@ -658,6 +687,16 @@
 
     if ([rtpReceiver.track.kind isEqualToString:@"audio"]) {
       [self ensureAudioSession];
+      NSString* trackId = rtpReceiver.track.trackId;
+      if (self.trackVolumeCache[trackId] == nil) {
+        self.trackVolumeCache[trackId] = @(1.0);
+      }
+      if (self.isAudioPlayoutPaused &&
+          [rtpReceiver.track isKindOfClass:[RTCAudioTrack class]]) {
+        RTCAudioTrack* audioTrack = (RTCAudioTrack*)rtpReceiver.track;
+        self.pausedTrackVolumes[trackId] = self.trackVolumeCache[trackId];
+        audioTrack.source.volume = 0.0;
+      }
     }
     postEvent(eventSink, event);
   }
@@ -666,6 +705,10 @@
 /** Called when the receiver and its track are removed. */
 - (void)peerConnection:(RTCPeerConnection*)peerConnection
      didRemoveReceiver:(RTCRtpReceiver*)rtpReceiver {
+  if (rtpReceiver.track != nil) {
+    [self.pausedTrackVolumes removeObjectForKey:rtpReceiver.track.trackId];
+    [self.trackVolumeCache removeObjectForKey:rtpReceiver.track.trackId];
+  }
 }
 
 /** Called when the selected ICE candidate pair is changed. */

--- a/common/darwin/Classes/FlutterWebRTCPlugin.h
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.h
@@ -81,6 +81,12 @@ typedef void (^CapturerStopHandler)(CompletionHandler _Nonnull handler);
 
 @property(nonatomic, strong) AudioManager* _Nullable audioManager;
 
+@property(nonatomic, strong)
+    NSMutableDictionary<NSString*, NSNumber*>* _Nonnull trackVolumeCache;
+@property(nonatomic, strong)
+    NSMutableDictionary<NSString*, NSNumber*>* _Nonnull pausedTrackVolumes;
+@property(nonatomic) BOOL isAudioPlayoutPaused;
+
 - (void)mediaStreamTrackSetVideoEffects:(nonnull NSString*)trackId
                                   names:(nonnull NSArray<NSString*>*)names;
 - (RTCMediaStream* _Nullable)streamForId:(NSString* _Nonnull)streamId

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -213,6 +213,9 @@ static FlutterWebRTCPlugin* sharedSingleton;
   self.videoCapturerStopHandlers = [NSMutableDictionary new];
   self.videoCaptureState = [NSMutableDictionary new];
   self.recorders = [NSMutableDictionary new];
+  self.trackVolumeCache = [NSMutableDictionary new];
+  self.pausedTrackVolumes = [NSMutableDictionary new];
+  self.isAudioPlayoutPaused = NO;
 #if TARGET_OS_IPHONE
   self.focusMode = @"locked";
   self.exposureMode = @"locked";
@@ -831,6 +834,11 @@ static FlutterWebRTCPlugin* sharedSingleton;
       [peerConnection close];
       [self.peerConnections removeObjectForKey:peerConnectionId];
 
+      for (NSString* trackId in peerConnection.remoteTracks) {
+        [self.pausedTrackVolumes removeObjectForKey:trackId];
+        [self.trackVolumeCache removeObjectForKey:trackId];
+      }
+
       // Clean up peerConnection's streams and tracks
       [peerConnection.remoteStreams removeAllObjects];
       [peerConnection.remoteTracks removeAllObjects];
@@ -1101,7 +1109,13 @@ static FlutterWebRTCPlugin* sharedSingleton;
     if (track != nil && [track isKindOfClass:[RTCAudioTrack class]]) {
       RTCAudioTrack* audioTrack = (RTCAudioTrack*)track;
       RTCAudioSource* audioSource = audioTrack.source;
-      audioSource.volume = [volume doubleValue];
+      self.trackVolumeCache[trackId] = volume;
+      if (self.pausedTrackVolumes[trackId] != nil) {
+        self.pausedTrackVolumes[trackId] = volume;
+        audioSource.volume = 0.0;
+      } else {
+        audioSource.volume = [volume doubleValue];
+      }
     }
     result(nil);
   } else if ([@"trackClone" isEqualToString:call.method]) {
@@ -1648,52 +1662,50 @@ static FlutterWebRTCPlugin* sharedSingleton;
     }
 #endif
   } else if ([@"resumeAudioPlayout" isEqualToString:call.method]) {
-    RTCAudioDeviceModule* adm = _peerConnectionFactory.audioDeviceModule;
-    if (adm == nil) {
-      result([FlutterError errorWithCode:@"resumeAudioPlayout failed"
-                                 message:@"Error: audioDeviceModule is nil"
-                                 details:nil]);
+    self.isAudioPlayoutPaused = NO;
+
+    if (self.pausedTrackVolumes.count == 0) {
+      result(nil);
       return;
     }
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-      NSInteger admResult = [adm initPlayout];
-      if (admResult == 0) {
-        admResult = [adm startPlayout];
+
+    NSDictionary<NSString*, NSNumber*>* volumesToRestore =
+        [NSDictionary dictionaryWithDictionary:self.pausedTrackVolumes];
+    [self.pausedTrackVolumes removeAllObjects];
+
+    for (NSString* trackId in volumesToRestore) {
+      double targetVolume = [volumesToRestore[trackId] doubleValue];
+      RTCMediaStreamTrack* track = [self trackForId:trackId peerConnectionId:nil];
+      if (track != nil && [track isKindOfClass:[RTCAudioTrack class]]) {
+        RTCAudioTrack* audioTrack = (RTCAudioTrack*)track;
+        audioTrack.source.volume = targetVolume;
+        self.trackVolumeCache[trackId] = @(targetVolume);
       }
-      dispatch_async(dispatch_get_main_queue(), ^{
-        if (admResult == 0) {
-          result(nil);
-        } else {
-          result([FlutterError
-              errorWithCode:@"resumeAudioPlayout failed"
-                    message:[NSString stringWithFormat:@"Error: adm api failed with code: %ld",
-                                                       (long)admResult]
-                    details:nil]);
-        }
-      });
-    });
-  } else if ([@"pauseAudioPlayout" isEqualToString:call.method]) {
-    RTCAudioDeviceModule* adm = _peerConnectionFactory.audioDeviceModule;
-    if (adm == nil) {
-      result([FlutterError errorWithCode:@"pauseAudioPlayout failed"
-                                 message:@"Error: audioDeviceModule is nil"
-                                 details:nil]);
-      return;
     }
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-      NSInteger admResult = [adm stopPlayout];
-      dispatch_async(dispatch_get_main_queue(), ^{
-        if (admResult == 0) {
-          result(nil);
-        } else {
-          result([FlutterError
-              errorWithCode:@"pauseAudioPlayout failed"
-                    message:[NSString stringWithFormat:@"Error: adm api failed with code: %ld",
-                                                       (long)admResult]
-                    details:nil]);
+
+    result(nil);
+  } else if ([@"pauseAudioPlayout" isEqualToString:call.method]) {
+    self.isAudioPlayoutPaused = YES;
+
+    for (NSString* peerConnectionId in _peerConnections) {
+      RTCPeerConnection* peerConnection = _peerConnections[peerConnectionId];
+      for (NSString* trackId in peerConnection.remoteTracks) {
+        RTCMediaStreamTrack* track = peerConnection.remoteTracks[trackId];
+        if ([track isKindOfClass:[RTCAudioTrack class]]) {
+          RTCAudioTrack* audioTrack = (RTCAudioTrack*)track;
+          if (self.pausedTrackVolumes[trackId] == nil) {
+            NSNumber* previousVolume = self.trackVolumeCache[trackId];
+            if (previousVolume == nil) {
+              previousVolume = @(1.0);
+            }
+            self.pausedTrackVolumes[trackId] = previousVolume;
+          }
+          audioTrack.source.volume = 0.0;
         }
-      });
-    });
+      }
+    }
+
+    result(nil);
   } else if ([@"startLocalRecording" isEqualToString:call.method]) {
     RTCAudioDeviceModule* adm = _peerConnectionFactory.audioDeviceModule;
     // Run on background queue

--- a/ios/stream_webrtc_flutter.podspec
+++ b/ios/stream_webrtc_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'stream_webrtc_flutter'
-  s.version          = '2.2.5'
+  s.version          = '2.2.6'
   s.summary          = 'Flutter WebRTC plugin for iOS.'
   s.description      = <<-DESC
 A new flutter plugin project.

--- a/ios/stream_webrtc_flutter/Sources/stream_webrtc_flutter/FlutterRTCPeerConnection.m
+++ b/ios/stream_webrtc_flutter/Sources/stream_webrtc_flutter/FlutterRTCPeerConnection.m
@@ -179,6 +179,11 @@
 - (void)peerConnectionClose:(RTCPeerConnection*)peerConnection {
   [peerConnection close];
 
+  for (NSString* trackId in peerConnection.remoteTracks) {
+    [self.pausedTrackVolumes removeObjectForKey:trackId];
+    [self.trackVolumeCache removeObjectForKey:trackId];
+  }
+
   // Clean up peerConnection's streams and tracks
   [peerConnection.remoteStreams removeAllObjects];
   [peerConnection.remoteTracks removeAllObjects];
@@ -412,6 +417,18 @@
   NSString* streamId = stream.streamId;
   peerConnection.remoteStreams[streamId] = stream;
 
+  if ([track isKindOfClass:[RTCAudioTrack class]]) {
+    RTCAudioTrack* audioTrack = (RTCAudioTrack*)track;
+    NSString* trackId = track.trackId;
+    if (self.trackVolumeCache[trackId] == nil) {
+      self.trackVolumeCache[trackId] = @(1.0);
+    }
+    if (self.isAudioPlayoutPaused) {
+      self.pausedTrackVolumes[trackId] = self.trackVolumeCache[trackId];
+      audioTrack.source.volume = 0.0;
+    }
+  }
+
   FlutterEventSink eventSink = peerConnection.eventSink;
   if (eventSink) {
     postEvent(eventSink, @{
@@ -434,6 +451,8 @@
            mediaStream:(RTCMediaStream*)stream
         didRemoveTrack:(RTCVideoTrack*)track {
   [peerConnection.remoteTracks removeObjectForKey:track.trackId];
+  [self.pausedTrackVolumes removeObjectForKey:track.trackId];
+  [self.trackVolumeCache removeObjectForKey:track.trackId];
   NSString* streamId = stream.streamId;
   FlutterEventSink eventSink = peerConnection.eventSink;
   if (eventSink) {
@@ -460,10 +479,18 @@
   BOOL hasAudio = NO;
   for (RTCAudioTrack* track in stream.audioTracks) {
     peerConnection.remoteTracks[track.trackId] = track;
+    NSString* trackId = track.trackId;
+    if (self.trackVolumeCache[trackId] == nil) {
+      self.trackVolumeCache[trackId] = @(1.0);
+    }
+    if (self.isAudioPlayoutPaused) {
+      self.pausedTrackVolumes[trackId] = self.trackVolumeCache[trackId];
+      track.source.volume = 0.0;
+    }
     [audioTracks addObject:@{
-      @"id" : track.trackId,
+      @"id" : trackId,
       @"kind" : track.kind,
-      @"label" : track.trackId,
+      @"label" : trackId,
       @"enabled" : @(track.isEnabled),
       @"remote" : @(YES),
       @"readyState" : @"live"
@@ -515,6 +542,8 @@
   }
   for (RTCAudioTrack* track in stream.audioTracks) {
     [peerConnection.remoteTracks removeObjectForKey:track.trackId];
+    [self.pausedTrackVolumes removeObjectForKey:track.trackId];
+    [self.trackVolumeCache removeObjectForKey:track.trackId];
   }
 
   FlutterEventSink eventSink = peerConnection.eventSink;
@@ -658,6 +687,16 @@
 
     if ([rtpReceiver.track.kind isEqualToString:@"audio"]) {
       [self ensureAudioSession];
+      NSString* trackId = rtpReceiver.track.trackId;
+      if (self.trackVolumeCache[trackId] == nil) {
+        self.trackVolumeCache[trackId] = @(1.0);
+      }
+      if (self.isAudioPlayoutPaused &&
+          [rtpReceiver.track isKindOfClass:[RTCAudioTrack class]]) {
+        RTCAudioTrack* audioTrack = (RTCAudioTrack*)rtpReceiver.track;
+        self.pausedTrackVolumes[trackId] = self.trackVolumeCache[trackId];
+        audioTrack.source.volume = 0.0;
+      }
     }
     postEvent(eventSink, event);
   }
@@ -666,6 +705,10 @@
 /** Called when the receiver and its track are removed. */
 - (void)peerConnection:(RTCPeerConnection*)peerConnection
      didRemoveReceiver:(RTCRtpReceiver*)rtpReceiver {
+  if (rtpReceiver.track != nil) {
+    [self.pausedTrackVolumes removeObjectForKey:rtpReceiver.track.trackId];
+    [self.trackVolumeCache removeObjectForKey:rtpReceiver.track.trackId];
+  }
 }
 
 /** Called when the selected ICE candidate pair is changed. */

--- a/ios/stream_webrtc_flutter/Sources/stream_webrtc_flutter/FlutterWebRTCPlugin.m
+++ b/ios/stream_webrtc_flutter/Sources/stream_webrtc_flutter/FlutterWebRTCPlugin.m
@@ -206,6 +206,9 @@ static FlutterWebRTCPlugin* sharedSingleton;
   self.videoCapturerStopHandlers = [NSMutableDictionary new];
   self.videoCaptureState = [NSMutableDictionary new];
   self.recorders = [NSMutableDictionary new];
+  self.trackVolumeCache = [NSMutableDictionary new];
+  self.pausedTrackVolumes = [NSMutableDictionary new];
+  self.isAudioPlayoutPaused = NO;
 #if TARGET_OS_IPHONE
   self.focusMode = @"locked";
   self.exposureMode = @"locked";
@@ -851,6 +854,11 @@ static FlutterWebRTCPlugin* sharedSingleton;
       [peerConnection close];
       [self.peerConnections removeObjectForKey:peerConnectionId];
 
+      for (NSString* trackId in peerConnection.remoteTracks) {
+        [self.pausedTrackVolumes removeObjectForKey:trackId];
+        [self.trackVolumeCache removeObjectForKey:trackId];
+      }
+
       // Clean up peerConnection's streams and tracks
       [peerConnection.remoteStreams removeAllObjects];
       [peerConnection.remoteTracks removeAllObjects];
@@ -1121,7 +1129,13 @@ static FlutterWebRTCPlugin* sharedSingleton;
     if (track != nil && [track isKindOfClass:[RTCAudioTrack class]]) {
       RTCAudioTrack* audioTrack = (RTCAudioTrack*)track;
       RTCAudioSource* audioSource = audioTrack.source;
-      audioSource.volume = [volume doubleValue];
+      self.trackVolumeCache[trackId] = volume;
+      if (self.pausedTrackVolumes[trackId] != nil) {
+        self.pausedTrackVolumes[trackId] = volume;
+        audioSource.volume = 0.0;
+      } else {
+        audioSource.volume = [volume doubleValue];
+      }
     }
     result(nil);
   } else if ([@"trackClone" isEqualToString:call.method]) {
@@ -1668,52 +1682,50 @@ static FlutterWebRTCPlugin* sharedSingleton;
     }
 #endif
   } else if ([@"resumeAudioPlayout" isEqualToString:call.method]) {
-    RTCAudioDeviceModule* adm = _peerConnectionFactory.audioDeviceModule;
-    if (adm == nil) {
-      result([FlutterError errorWithCode:@"resumeAudioPlayout failed"
-                                 message:@"Error: audioDeviceModule is nil"
-                                 details:nil]);
+    self.isAudioPlayoutPaused = NO;
+
+    if (self.pausedTrackVolumes.count == 0) {
+      result(nil);
       return;
     }
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-      NSInteger admResult = [adm initPlayout];
-      if (admResult == 0) {
-        admResult = [adm startPlayout];
+
+    NSDictionary<NSString*, NSNumber*>* volumesToRestore =
+        [NSDictionary dictionaryWithDictionary:self.pausedTrackVolumes];
+    [self.pausedTrackVolumes removeAllObjects];
+
+    for (NSString* trackId in volumesToRestore) {
+      double targetVolume = [volumesToRestore[trackId] doubleValue];
+      RTCMediaStreamTrack* track = [self trackForId:trackId peerConnectionId:nil];
+      if (track != nil && [track isKindOfClass:[RTCAudioTrack class]]) {
+        RTCAudioTrack* audioTrack = (RTCAudioTrack*)track;
+        audioTrack.source.volume = targetVolume;
+        self.trackVolumeCache[trackId] = @(targetVolume);
       }
-      dispatch_async(dispatch_get_main_queue(), ^{
-        if (admResult == 0) {
-          result(nil);
-        } else {
-          result([FlutterError
-              errorWithCode:@"resumeAudioPlayout failed"
-                    message:[NSString stringWithFormat:@"Error: adm api failed with code: %ld",
-                                                       (long)admResult]
-                    details:nil]);
-        }
-      });
-    });
-  } else if ([@"pauseAudioPlayout" isEqualToString:call.method]) {
-    RTCAudioDeviceModule* adm = _peerConnectionFactory.audioDeviceModule;
-    if (adm == nil) {
-      result([FlutterError errorWithCode:@"pauseAudioPlayout failed"
-                                 message:@"Error: audioDeviceModule is nil"
-                                 details:nil]);
-      return;
     }
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-      NSInteger admResult = [adm stopPlayout];
-      dispatch_async(dispatch_get_main_queue(), ^{
-        if (admResult == 0) {
-          result(nil);
-        } else {
-          result([FlutterError
-              errorWithCode:@"pauseAudioPlayout failed"
-                    message:[NSString stringWithFormat:@"Error: adm api failed with code: %ld",
-                                                       (long)admResult]
-                    details:nil]);
+
+    result(nil);
+  } else if ([@"pauseAudioPlayout" isEqualToString:call.method]) {
+    self.isAudioPlayoutPaused = YES;
+
+    for (NSString* peerConnectionId in _peerConnections) {
+      RTCPeerConnection* peerConnection = _peerConnections[peerConnectionId];
+      for (NSString* trackId in peerConnection.remoteTracks) {
+        RTCMediaStreamTrack* track = peerConnection.remoteTracks[trackId];
+        if ([track isKindOfClass:[RTCAudioTrack class]]) {
+          RTCAudioTrack* audioTrack = (RTCAudioTrack*)track;
+          if (self.pausedTrackVolumes[trackId] == nil) {
+            NSNumber* previousVolume = self.trackVolumeCache[trackId];
+            if (previousVolume == nil) {
+              previousVolume = @(1.0);
+            }
+            self.pausedTrackVolumes[trackId] = previousVolume;
+          }
+          audioTrack.source.volume = 0.0;
         }
-      });
-    });
+      }
+    }
+
+    result(nil);
   } else if ([@"startLocalRecording" isEqualToString:call.method]) {
     RTCAudioDeviceModule* adm = _peerConnectionFactory.audioDeviceModule;
     // Run on background queue

--- a/ios/stream_webrtc_flutter/Sources/stream_webrtc_flutter/include/stream_webrtc_flutter/FlutterWebRTCPlugin.h
+++ b/ios/stream_webrtc_flutter/Sources/stream_webrtc_flutter/include/stream_webrtc_flutter/FlutterWebRTCPlugin.h
@@ -72,6 +72,12 @@ typedef void (^CapturerStopHandler)(CompletionHandler _Nonnull handler);
 
 @property(nonatomic, strong) AudioManager* _Nullable audioManager;
 
+@property(nonatomic, strong)
+    NSMutableDictionary<NSString*, NSNumber*>* _Nonnull trackVolumeCache;
+@property(nonatomic, strong)
+    NSMutableDictionary<NSString*, NSNumber*>* _Nonnull pausedTrackVolumes;
+@property(nonatomic) BOOL isAudioPlayoutPaused;
+
 - (void)mediaStreamTrackSetVideoEffects:(nonnull NSString*)trackId
                                   names:(nonnull NSArray<NSString*>*)names;
 - (RTCMediaStream* _Nullable)streamForId:(NSString* _Nonnull)streamId

--- a/macos/stream_webrtc_flutter.podspec
+++ b/macos/stream_webrtc_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'stream_webrtc_flutter'
-  s.version          = '2.2.5'
+  s.version          = '2.2.6'
   s.summary          = 'Flutter WebRTC plugin for macOS.'
   s.description      = <<-DESC
 A new flutter plugin project.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stream_webrtc_flutter
 description: Flutter WebRTC plugin for iOS/Android/Destkop/Web, based on GoogleWebRTC.
-version: 2.2.5
+version: 2.2.6
 homepage: https://github.com/GetStream/webrtc-flutter
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
Fix iOS `pauseAudioPlayout` by using track-level volume muting (like we already do on Android) instead of stopping the Audio Device Module