### PR TITLE
fix(iOS): remove private api use from broadcast picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+Upcoming
+
+* [iOS] fix: trigger the screen-share broadcast picker (`RPSystemBroadcastPickerView`) via public APIs instead of the private `buttonPressed:` selector.
+
 [3.0.1] - 2026.07.10
 
 * [iOS] Added an onAudioRouteChangeEvent that fires whenever audio output route changes.

--- a/ios/stream_webrtc_flutter/Sources/stream_webrtc_flutter/FlutterRTCDesktopCapturer.m
+++ b/ios/stream_webrtc_flutter/Sources/stream_webrtc_flutter/FlutterRTCDesktopCapturer.m
@@ -77,9 +77,20 @@ NSArray<RTCDesktopSource*>* _captureSources;
     } else {
       NSLog(@"Not able to find the %@ key", kRTCScreenSharingExtension);
     }
-    SEL selector = NSSelectorFromString(@"buttonPressed:");
-    if ([picker respondsToSelector:selector]) {
-      [picker performSelector:selector withObject:nil];
+    // Trigger the picker's internal button via public UIControl APIs only.
+    // Calling the private buttonPressed: selector gets apps rejected under
+    // App Store Guideline 2.5.1 (non-public API).
+    UIButton* pickerButton = nil;
+    for (UIView* subview in picker.subviews) {
+      if ([subview isKindOfClass:[UIButton class]]) {
+        pickerButton = (UIButton*)subview;
+        break;
+      }
+    }
+    if (pickerButton != nil) {
+      [pickerButton sendActionsForControlEvents:UIControlEventTouchUpInside];
+    } else {
+      NSLog(@"RPSystemBroadcastPickerView button not found, broadcast picker was not presented");
     }
   }
 #endif
@@ -152,15 +163,14 @@ NSArray<RTCDesktopSource*>* _captureSources;
   };
 #endif
 
-  RTCVideoTrack* videoTrack = [nf.factory videoTrackWithSource:videoSource
-                                                       trackId:trackUUID];
+  RTCVideoTrack* videoTrack = [nf.factory videoTrackWithSource:videoSource trackId:trackUUID];
   [mediaStream addVideoTrack:videoTrack];
 
   LocalVideoTrack* localVideoTrack = [[LocalVideoTrack alloc] initWithTrack:videoTrack
                                                             videoProcessing:videoProcessingAdapter];
 
   [self.localTracks setObject:localVideoTrack forKey:trackUUID];
-  
+
   if (nf.factoryId != nil) {
     self.trackFactoryId[trackUUID] = nf.factoryId;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed iOS screen sharing so the broadcast picker opens using supported system interactions.
  * Added handling and logging for cases where the broadcast picker control cannot be located.

* **Documentation**
  * Added an upcoming release note describing the iOS screen-sharing fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->